### PR TITLE
Labs-ui deprecated templates; point only to other deprecated templates

### DIFF
--- a/addon/templates/components/deprecated/layer-group-toggle.hbs
+++ b/addon/templates/components/deprecated/layer-group-toggle.hbs
@@ -11,20 +11,20 @@
         {{label}}
         {{#if active}}
           {{#if icon}}
-            {{labs-ui/legend-icon icon=icon}}
+            {{deprecated/legend-icon icon=icon}}
           {{/if}}
         {{/if}}
       </span>
     </div>
     <div class="cell shrink layer-group-toggle-icons">
       {{#if (and activeTooltip active)}}
-        {{labs-ui/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left' fixedWith=true}}
+        {{deprecated/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left' fixedWith=true}}
       {{/if}}
       {{#if infoLink}}
         <a href="{{infoLink}}" target="_blank" class="info-link"><FaIcon @icon={{infoLinkIcon}} @fixedWidth={{true}} /></a>
       {{/if}}
       {{#if tooltip}}
-        {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left' fixedWidth=true}}
+        {{deprecated/icon-tooltip tip=tooltip icon=tooltipIcon side='left' fixedWidth=true}}
       {{/if}}
     </div>
   </div>

--- a/addon/templates/components/deprecated/layer-groups-container.hbs
+++ b/addon/templates/components/deprecated/layer-groups-container.hbs
@@ -11,7 +11,7 @@
 </div>
 <div class="layer-groups-container-content">
   {{yield (hash
-      layer-group-toggle=(component 'labs-ui/layer-group-toggle' willDestroyHook=(action 'unregisterChild') didInit=(action 'registerChild'))
+      layer-group-toggle=(component 'deprecated/layer-group-toggle' willDestroyHook=(action 'unregisterChild') didInit=(action 'registerChild'))
     )
   }}
 </div>

--- a/addon/templates/components/deprecated/legend-icon.hbs
+++ b/addon/templates/components/deprecated/legend-icon.hbs
@@ -2,15 +2,15 @@
   {{#each icon.layers as |icon-layer|}}
 
     {{#if (eq icon.type 'line')}}
-      {{labs-ui/icons/line options=icon-layer}}
+      {{deprecated/icons/line options=icon-layer}}
     {{/if}}
 
     {{#if (eq icon.type 'rectangle')}}
-      {{labs-ui/icons/rectangle options=icon-layer}}
+      {{deprecated/icons/rectangle options=icon-layer}}
     {{/if}}
 
     {{#if (eq icon.type 'fa-icon')}}
-      {{labs-ui/icons/fa-icon options=icon-layer}}
+      {{deprecated/icons/fa-icon options=icon-layer}}
     {{/if}}
 
   {{/each}}

--- a/addon/templates/components/deprecated/legend-item.hbs
+++ b/addon/templates/components/deprecated/legend-item.hbs
@@ -5,7 +5,7 @@
   </div>
   <div class="cell shrink">
     {{#if item.tooltip}}
-      {{labs-ui/icon-tooltip tip=item.tooltip side='left' fixedWidth=true}}
+      {{deprecated/icon-tooltip tip=item.tooltip side='left' fixedWidth=true}}
     {{/if}}
   </div>
 </div>

--- a/addon/templates/components/deprecated/legend-item.hbs
+++ b/addon/templates/components/deprecated/legend-item.hbs
@@ -1,6 +1,6 @@
 <div class="grid-x">
   <div class="cell auto">
-    {{labs-ui/legend-icon icon=item.icon}}
+    {{deprecated/legend-icon icon=item.icon}}
     {{item.label}}
   </div>
   <div class="cell shrink">

--- a/addon/templates/components/deprecated/legend-items.hbs
+++ b/addon/templates/components/deprecated/legend-items.hbs
@@ -1,3 +1,3 @@
 {{#each items as |item|}}
-  {{labs-ui/legend-item item=item}}
+  {{deprecated/legend-item item=item}}
 {{/each}}


### PR DESCRIPTION
# Description
Bug AB#13200 for waterfront access notes the entry point icon is incorrect. This can be traced back to the template for the deprecated legend - item pointing to a non-deprecated icon component.

# Changes
- The first commit isolates the update to only the icon component noted in the bug.
- The next commit updates all deprecated templates to only point to other deprecated templates
  
 # Tickets
Bug AB#13200
Task AB#13291 