### PR TITLE
Task/13852 Deprecated UI bind icon attributes

### DIFF
--- a/addon/components/deprecated/icons/line.js
+++ b/addon/components/deprecated/icons/line.js
@@ -9,6 +9,7 @@ export default Component.extend({
 
   classNames: ['legend-icon-layer', 'line'],
   tagName: 'svg',
+  attributeBindings: ['height', 'width', 'viewBox', 'preserveAspectRatio'],
   layout,
 
   svgOptions: computed('options', function() {

--- a/addon/components/deprecated/icons/rectangle.js
+++ b/addon/components/deprecated/icons/rectangle.js
@@ -9,6 +9,7 @@ export default Component.extend({
 
   tagName: 'svg',
   classNames: ['legend-icon-layer', 'rectangle'],
+  attributeBindings: ['height', 'width', 'viewBox', 'preserveAspectRatio'],
 
   layout,
 


### PR DESCRIPTION
# Description
Bind custom attributes in line and rectangle icons

## Semver recommendation
This is a bug fix and should be a patch

## Tickets
AB#13852

## Additional details
Labs/UI also has the same issue. However, `attributeBindings` is invalid syntax for its components; the fix is not applied to these components.