### PR TITLE
14424 Improve Analytics for Search Queries

### DIFF
--- a/addon/components/labs-search.js
+++ b/addon/components/labs-search.js
@@ -153,6 +153,8 @@ export default Component.extend({
       event.initEvent('blur', true, false);
       el.dispatchEvent(event);
   
+      result.searchQuery = this.get('searchTerms');
+      
       this.setProperties({
         selected: 0,
         searchTerms: result.label,


### PR DESCRIPTION
Upon selection of a search result, the search box text is updated to reflect the full label of the result.  This change allows us to capture what the search query was before it is overwritten, so that we can pass the query along to analytics.


Completes a portion of [AB#14424](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14424).  The other portion will need to be completed in labs-zola.